### PR TITLE
Challonge Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 Thumbs.db
 config.js*
+.node-xmlhttprequest-sync-*

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -8,6 +8,8 @@ module.exports = function(io) {
     var challongeHash = null;
     var matches = [];
     var players = [];
+    //Used to check for updates
+    var availableMatchesCache = [];
 
     var challongeIO = io.of('/challonge');
 
@@ -22,34 +24,34 @@ module.exports = function(io) {
         });
 
         socket.on('update challonge', function(msg) {
+            var urlChanged = msg.challongeUrl != challongeData.challongeUrl;
             challongeData = msg;
             if (challongeData.challongeUrl) {
-                if (!challongeHash) {
+                if (!challongeHash || urlChanged) {
                     challongeHash = createChallongeHash(challongeData.challongeUrl);
-                }
-
-                getchallongePollableData(challongeData);
-                setTimeout(pollChallonge, challongePollFrequency);
+                    pollChallonge();
+                }   
             }
 
-            challongeIO.emit('update challonge', challongeData);
+            //challongeIO.emit('update challonge', challongeData);
             console.log('update challonge: ' + JSON.stringify(challongeData));
         });
 
         function pollChallonge() {
-            getchallongePollableData(challongeData);
+            getChallongePollableData(challongeData);
             if (connectedSockets > 0 && challongeHash)
               setTimeout(pollChallonge, challongePollFrequency);
         }
 
-        function getchallongePollableData(challongeData) {
+        function getChallongePollableData(challongeData) {
             console.log('Polling challonge for updates...');
             challongeData = fetchChallongeData(challongeData);
             challongeData.upcomingMatches = getUpcomingMatches();
+            challongeData = checkForMatchUpdates(challongeData);
             challongeData.players = getPlayerDictionary();
             //console.log('New challonge Pollable Data: ' + JSON.stringify(challongeData));
             console.log('Challonge update complete');
-            socket.emit('update challonge', challongeData);
+            challongeIO.emit('update challonge', challongeData);
         }
 
         function fetchChallongeData(challongeData) {
@@ -57,7 +59,7 @@ module.exports = function(io) {
             var xmlhttp = new XMLHttpRequest();
             xmlhttp.open('GET', requestUrl, false);
             //Basic Auth must be encoded or request will be denied
-            xmlhttp.setRequestHeader("Authorization", "Basic " + new Buffer('Camtendo' + ':' + config.challongeApiKey).toString('base64')); 
+            xmlhttp.setRequestHeader("Authorization", "Basic " + new Buffer(config.challongeDevUsername + ':' + config.challongeApiKey).toString('base64')); 
             xmlhttp.send();
             console.log('Requesting tournament data for ' + challongeData.challongeUrl);
             var challongeResponse = JSON.parse(xmlhttp.responseText);
@@ -102,6 +104,56 @@ module.exports = function(io) {
             //Standard tournament
             challongeHash = tourneyHash;
             return challongeHash;
+        }
+
+        function checkForMatchUpdates(challongeData) {
+            if (Object.equals(challongeData.upcomingMatches, availableMatchesCache)) {
+                challongeData.matchesChanged = false;
+            }
+            else {
+                challongeData.matchesChanged = true;
+                availableMatchesCache = challongeData.upcomingMatches;
+                console.log('Matches changed. Will alert clients.');
+            }
+
+            return challongeData;
+        }
+
+        //Used to detect match changes with high accuracy
+        //https://stackoverflow.com/questions/1068834/object-comparison-in-javascript
+        Object.equals = function( x, y ) {
+          if ( x === y ) return true;
+            // if both x and y are null or undefined and exactly the same
+
+          if ( ! ( x instanceof Object ) || ! ( y instanceof Object ) ) return false;
+            // if they are not strictly equal, they both need to be Objects
+
+          if ( x.constructor !== y.constructor ) return false;
+            // they must have the exact same prototype chain, the closest we can do is
+            // test there constructor.
+
+          for ( var p in x ) {
+            if ( ! x.hasOwnProperty( p ) ) continue;
+              // other properties were tested using x.constructor === y.constructor
+
+            if ( ! y.hasOwnProperty( p ) ) return false;
+              // allows to compare x[ p ] and y[ p ] when set to undefined
+
+            if ( x[ p ] === y[ p ] ) continue;
+              // if they have the same strict value or identity then they are equal
+
+            if ( typeof( x[ p ] ) !== "object" ) return false;
+              // Numbers, Strings, Functions, Booleans must be strictly equal
+
+            if ( ! Object.equals( x[ p ],  y[ p ] ) ) return false;
+              // Objects and Arrays must be tested recursively
+          }
+
+          for ( p in y ) {
+            if ( y.hasOwnProperty( p ) && ! x.hasOwnProperty( p ) ) return false;
+              // allows x[ p ] to be set to undefined
+          }
+          return true;
         }
     });
 }

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -38,7 +38,7 @@ module.exports = function(io) {
 
         function pollChallonge() {
             getchallongePollableData(challongeData);
-            if (connectedSockets > 0 && challongeData.challongeUsername)
+            if (connectedSockets > 0 && challongeHash)
               setTimeout(pollChallonge, challongePollFrequency);
         }
 
@@ -47,8 +47,9 @@ module.exports = function(io) {
             challongeData = fetchChallongeData(challongeData);
             challongeData.upcomingMatches = getUpcomingMatches();
             challongeData.players = getPlayerDictionary();
-            console.log('New challonge Pollable Data: ' + JSON.stringify(challongeData));
-            socket.emit('update challonge readonly data', challongeData);
+            //console.log('New challonge Pollable Data: ' + JSON.stringify(challongeData));
+            console.log('Challonge update complete');
+            socket.emit('update challonge', challongeData);
         }
 
         function fetchChallongeData(challongeData) {

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -1,0 +1,92 @@
+var config = require('../config');
+var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
+module.exports = function(io) {
+    var challongeData = {};
+    var challongePollFrequency = 10000;
+    var connectedSockets = 0;
+    var challongeApiRoot = 'https://Camtendo:'+config.challongeApiKey+'@api.challonge.com/v1';
+    var challongeHash = '';
+    var matches = [];
+    var players = [];
+
+    var challongeIO = io.of('/challonge');
+
+    challongeIO.on('connection', function(socket) {
+        console.log('Challonge connected');
+        socket.emit('update challonge', challonge);
+        connectedSockets++;
+
+        socket.on('disconnect', function() {
+            console.log('Challonge disconnected');
+            connectedSockets--;
+        });
+
+        socket.on('update challonge', function(msg) {
+            challongeData = msg;
+            if (challongeData.challongeUrl) {
+                if (!challongeHash) {
+                    challongeData = createChallongeHash(challongeData.challongeUrl);
+                }
+
+                getchallongePollableData(challongeData);
+                setTimeout(pollchallonge, challongePollFrequency);
+            }
+
+            challongeIO.emit('update challonge', challongeData);
+            console.log('update challonge: ' + JSON.stringify(challongeData));
+        });
+
+        function pollChallonge() {
+            getchallongePollableData(challongeData);
+            if (connectedSockets > 0 && challongeData.challongeUsername)
+              setTimeout(pollchallonge, challongePollFrequency);
+        }
+
+        function getchallongePollableData(challongeData) {
+            console.log('Polling challonge for updates...');
+            challongeData = fetchChallongeData(challongeData);
+            challongeData.upcomingMatches = getUpcomingMatches();
+            console.log('New challonge Pollable Data: ' + JSON.stringify(challongeData));
+            socket.emit('update challonge readonly data', challongeData);
+        }
+
+        function fetchChallongeData(challongeData) {
+            var requestUrl = challongeApiRoot + '/tournaments/' + challongeHash + '.json?include_matches=1&include_participants=1';
+            var xmlhttp = new XMLHttpRequest();
+            xmlhttp.open('GET', requestUrl, false);
+            xmlhttp.send();
+            console.log('Requesting channel data for ' + challongeData.challongeUrl);
+            var challongeResponse = JSON.parse(xmlhttp.responseText);
+            matches = challongeResponse.tournament.matches;
+            players = challongeResponse.tournament.participants;
+            return challongeData;
+        }
+
+        function getUpcomingMatches() {
+            var upcomingMatches = [];
+            matches.forEach(function(match){
+                //Their JSON sucks
+                if (match.match.state == 'open') {
+                    upcomingMatches.push(match);
+                }
+            });
+
+            return upcomingMatches;
+        }
+
+        function createChallongeHash(challongeUrl) {
+            tourneyHash = challongeUrl.substring(challongeUrl.lastIndexOf('/') + 1).trim();
+
+            //If tournament belongs to an organization,
+            //it must be specified in the request
+            if (challongeUrl.split('.').length - 1 > 1) {
+                orgHash = challongeUrl.substring(challongeUrl.lastIndexOf('http://') + 7, challongeUrl.indexOf('.'));
+                challongeHash = orgHash + '-' + tourneyHash;    
+                return;
+            }
+
+            //Standard tournament
+            challongeHash = tourneyHash;
+        }
+    });
+}

--- a/sockets/index.js
+++ b/sockets/index.js
@@ -3,4 +3,5 @@ module.exports = function (io) {
   require('./overlay')(io);
   require('./pardonthesmash')(io);
   require('./twitch')(io);
+  require('./challonge')(io);
 }

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -154,12 +154,15 @@
 	}
 
 	var challongeSocket = io('/challonge');
+	var challongeMatches = [];
 
 	challongeSocket.on('update challonge', function(data){
 		document.getElementById('challongeUrl').value = data.challongeUrl || "";
 
-		if(data.upcomingMatches)
+		if(data.upcomingMatches && data.matchesChanged) {
+			challongeMatches = data.upcomingMatches;
 			createMatchList(data);
+		}
 		embedChallongeBracket(data);
 	});
 
@@ -231,6 +234,7 @@
 
 		var defaultOption = document.createElement('option');
 		defaultOption.text = 'Select a match to display';
+		defaultOption.value = null;
 		selectList.appendChild(defaultOption);
 
 		data.upcomingMatches.forEach(function(match){
@@ -238,19 +242,33 @@
 			var playerOne = data.players[match.match.player1_id];
 			var playerTwo = data.players[match.match.player2_id];
 			option.text = match.match.identifier+': '+playerOne+' vs. '+playerTwo;
-			option.value = playerOne+','+playerTwo;
+			option.value = match.match.identifier;
 			selectList.appendChild(option);
 		});
 
 		$('#challongeMatchList').change(function(){
 			var selectedOption = $('#challongeMatchList option:selected');
-			if (selectedOption.text().indexOf('vs.') > -1) {
-				playerArray = selectedOption.val().split(',');
-				document.getElementById('lplayer').value = playerArray[0];
-				document.getElementById('rplayer').value = playerArray[1];
+			var identifier = selectedOption.val();
+			if (selectedOption.val()) {
+				console.log('Updating match...');
+				var match = getMatchForIdentifier(identifier);
+				var playerOne = data.players[match.match.player1_id];
+				var playerTwo = data.players[match.match.player2_id];
+				document.getElementById('lplayer').value = playerOne;
+				document.getElementById('rplayer').value = playerTwo;
 				sendUpdate();
 			}
 		});
+	}
+
+	function getMatchForIdentifier(identifier) {
+		//Sublime Text autocompleted a backwards loop because they are fast
+		for (var i = challongeMatches.length - 1; i >= 0; i--) {
+			if (challongeMatches[i].match.identifier == identifier)
+				return challongeMatches[i];
+		};
+
+		return null;
 	}
 
 	function toastNotify() {

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -90,6 +90,21 @@
 	</p>
 </form>
 
+<!--Challonge Form-->
+<form action="javascript:sendChallongeUpdate()">
+	<h2>Challonge</h2>
+	<p>
+		<label for="challongeUrl">
+			Challonge URL:
+			<input id="challongeUrl"></input>
+		</label>
+	</p>
+	<p id="challongeMatchListPlaceholder"></p>
+	<p>
+	<input type="submit"/>
+	</p>
+</form>
+
 <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
 <script src="/socket.io/socket.io.js"></script>
 <script>
@@ -137,6 +152,15 @@
 		}
 	}
 
+	var challongeSocket = io('/challonge');
+
+	challongeSocket.on('update challonge', function(data){
+		document.getElementById('challongeUrl').value = data.challongeUrl || "";
+
+		if(data.upcomingMatches)
+			createMatchList(data);
+	});
+
 	function plusOneLeft() {
 		var numVal = parseInt(document.getElementById('lscore').value);
 		document.getElementById('lscore').value = numVal + 1;
@@ -183,6 +207,44 @@
 		};
 		twitchSocket.emit('update twitch', data);
 		toastNotify();
+	}
+
+	function sendChallongeUpdate() {
+		var data = {
+			'challongeUrl': document.getElementById('challongeUrl').value,
+		};
+		challongeSocket.emit('update challonge', data);
+		toastNotify();
+	}
+
+	function createMatchList(data) {
+		var selectList = document.createElement('select');
+		selectList.id = 'challongeMatchList';
+		document.getElementById('challongeMatchListPlaceholder').appendChild(selectList);
+
+		var defaultOption = document.createElement('option');
+		defaultOption.text = 'Select a match to display';
+		defaultOption.selected = 'selected';
+		selectList.appendChild(defaultOption);
+
+		data.upcomingMatches.forEach(function(match){
+			var option = document.createElement('option');
+			var playerOne = data.players[match.match.player1_id];
+			var playerTwo = data.players[match.match.player2_id];
+			option.text = match.match.identifier+': '+playerOne+' vs. '+playerTwo;
+			option.value = playerOne+','+playerTwo;
+			selectList.appendChild(option);
+		});
+
+		$('#challongeMatchList').change(function(){
+			var selectedOption = $('#challongeMatchList option:selected');
+			if (selectedOption.text().indexOf('vs.') > -1) {
+				playerArray = selectedOption.val().split(',');
+				document.getElementById('lplayer').value = playerArray[0];
+				document.getElementById('rplayer').value = playerArray[1];
+				sendUpdate();
+			}
+		});
 	}
 
 	function toastNotify() {

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -100,6 +100,7 @@
 		</label>
 	</p>
 	<p id="challongeMatchListPlaceholder"></p>
+	<p id="challongeEmbedPlaceholder"></p>
 	<p>
 	<input type="submit"/>
 	</p>
@@ -159,6 +160,7 @@
 
 		if(data.upcomingMatches)
 			createMatchList(data);
+		embedChallongeBracket(data);
 	});
 
 	function plusOneLeft() {
@@ -218,11 +220,9 @@
 	}
 
 	function createMatchList(data) {
-		console.log('Creating match list...');
 		var matchList = $('#challongeMatchList');
 		if (matchList) {
 			matchList.remove();
-			console.log('Destroyed old match list.');
 		}
 
 		var selectList = document.createElement('select');
@@ -231,7 +231,6 @@
 
 		var defaultOption = document.createElement('option');
 		defaultOption.text = 'Select a match to display';
-		//defaultOption.selected = 'selected';
 		selectList.appendChild(defaultOption);
 
 		data.upcomingMatches.forEach(function(match){
@@ -259,6 +258,20 @@
 		var info = $('#info');
 		info.show();
 		info.fadeOut(1200);
+	}
+
+	function embedChallongeBracket(data) {
+		var bracket = document.getElementById('challongeBracket');
+		if (data.challongeUrl && bracket == null) {
+			var embedded = document.createElement('iframe');
+			embedded.id = 'challongeBracket';
+			embedded.src = data.challongeUrl+'/module';
+			embedded.width = '100%';
+			embedded.height = '500';
+			embedded.frameboarder = '0';
+			embedded.scrolling = 'auto';
+			document.getElementById('challongeEmbedPlaceholder').appendChild(embedded);
+		}
 	}
 
 	function toggleNightMode() {

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -218,13 +218,20 @@
 	}
 
 	function createMatchList(data) {
+		console.log('Creating match list...');
+		var matchList = $('#challongeMatchList');
+		if (matchList) {
+			matchList.remove();
+			console.log('Destroyed old match list.');
+		}
+
 		var selectList = document.createElement('select');
 		selectList.id = 'challongeMatchList';
 		document.getElementById('challongeMatchListPlaceholder').appendChild(selectList);
 
 		var defaultOption = document.createElement('option');
 		defaultOption.text = 'Select a match to display';
-		defaultOption.selected = 'selected';
+		//defaultOption.selected = 'selected';
 		selectList.appendChild(defaultOption);
 
 		data.upcomingMatches.forEach(function(match){


### PR DESCRIPTION
Allows you to do the following with the Challonge API:

+ Fetch matches and player names with high frequency
+ Choose which match to fill in the original overlay form (currently only sets player names), and posts immediately
+ Embed a Challonge bracket into the admin page (can directly edit tournament assuming logged in)