### PR TITLE
Refactor twitch and challonge to account for async calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "morgan": "~1.3.0",
     "request": "^2.51.0",
     "serve-favicon": "~2.1.3",
-    "socket.io": "^1.2.1",
-    "xmlhttprequest": "^1.6.0"
+    "socket.io": "^1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "~4.9.0",
     "hbs": "~2.7.0",
     "morgan": "~1.3.0",
+    "request": "^2.51.0",
     "serve-favicon": "~2.1.3",
     "socket.io": "^1.2.1",
     "xmlhttprequest": "^1.6.0"

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -10,3 +10,7 @@ a {
 td {
 	padding: 10px;
 }
+
+.hide-by-default {
+	display: none;
+}

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -16,7 +16,9 @@ module.exports = function(io) {
     var challongeIO = io.of('/challonge');
 
     challongeIO.on('connection', function(socket) {
-        console.log('Challonge connected');
+        // Log the new connection
+        console.log('challonge user connected: ' + socket.handshake.address + ' -> ' + socket.request.headers.referer);
+
         socket.emit('update challonge', challongeData);
         connectedSockets++;
 
@@ -24,7 +26,7 @@ module.exports = function(io) {
         pollChallonge();
 
         socket.on('disconnect', function() {
-            console.log('Challonge disconnected');
+            console.log('challonge user disconnected: ' + socket.handshake.address);
             connectedSockets--;
             if (connectedSockets <= 0) {
                 connectedSockets = 0;

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -20,9 +20,15 @@ module.exports = function(io) {
         socket.emit('update challonge', challongeData);
         connectedSockets++;
 
+        // if we go from 0 to 1 socket, start polling again
+        pollChallonge();
+
         socket.on('disconnect', function() {
             console.log('Challonge disconnected');
             connectedSockets--;
+            if (connectedSockets === 0) {
+                clearTimeout(timeout);
+            }
         });
 
         socket.on('update challonge', function(msg) {

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -26,7 +26,8 @@ module.exports = function(io) {
         socket.on('disconnect', function() {
             console.log('Challonge disconnected');
             connectedSockets--;
-            if (connectedSockets === 0) {
+            if (connectedSockets <= 0) {
+                connectedSockets = 0;
                 clearTimeout(timeout);
             }
         });

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -62,7 +62,6 @@ module.exports = function(io) {
                 availableMatchesCache = challongeData.upcomingMatches;
                 challongeData.players = getPlayerDictionary();
                 console.log('Sending challonge update');
-                console.log(challongeData);
                 challongeIO.emit('update challonge', challongeData);
             }
         }

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -1,6 +1,6 @@
 var config = require('../config');
-var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
 var request = require('request');
+
 module.exports = function(io) {
     var challongeData = {};
     var challongePollFrequency = 10000;

--- a/sockets/twitch.js
+++ b/sockets/twitch.js
@@ -11,7 +11,9 @@ module.exports = function(io) {
     var twitchIO = io.of('/twitch');
 
     twitchIO.on('connection', function (socket) {
-        console.log('Connected to Twitch');
+        // Log the new connection
+        console.log('twitch user connected: ' + socket.handshake.address + ' -> ' + socket.request.headers.referer);
+
         socket.emit('send twitch data', twitchData);
         connectedSockets++;
 
@@ -19,7 +21,7 @@ module.exports = function(io) {
         pollTwitch();
 
         socket.on('disconnect', function () {
-            console.log('Twitch disconnected');
+            console.log('twitch user disconnected: ' + socket.handshake.address);
             connectedSockets--;
             if (connectedSockets <= 0) {
                 connectedSockets = 0;

--- a/sockets/twitch.js
+++ b/sockets/twitch.js
@@ -6,13 +6,13 @@ module.exports = function(io) {
     var twitchData = {};
     //In millis
     var twitchPollFrequency = 30000;
-    var twitchPollCache = {};
     var connectedSockets = 0;
+    var timeout = null;
 
     var twitchIO = io.of('/twitch');
 
     twitchIO.on('connection', function(socket) {
-        console.log('Twitch connected');
+        console.log('Connected to Twitch');
         socket.emit('send twitch data', twitchData);
         connectedSockets++;
 
@@ -30,15 +30,15 @@ module.exports = function(io) {
                     twitchData = updateTwitchData(twitchData);
                 }
 
-                twitchPollCache = twitchData;
-                getTwitchPollableData();
+                clearTimeout(timeout);
+                pollTwitch();
             }
         });
 
         function pollTwitch() {
             getTwitchPollableData();
             if (connectedSockets > 0 && twitchData.twitchUsername)
-              setTimeout(pollTwitch, twitchPollFrequency);
+              timeout = setTimeout(pollTwitch, twitchPollFrequency);
         }
 
         function getTwitchPollableData() {
@@ -197,7 +197,6 @@ module.exports = function(io) {
                     'status': status
                 }
             };
-
             var stringQuery = JSON.stringify(queryData);
             var contentLength = stringQuery.length;
 

--- a/sockets/twitch.js
+++ b/sockets/twitch.js
@@ -1,6 +1,4 @@
 var config = require('../config');
-//npm install xmlhttprequest if this fails
-var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
 var request = require('request');
 module.exports = function(io) {
     var twitchData = {};

--- a/sockets/twitch.js
+++ b/sockets/twitch.js
@@ -14,9 +14,15 @@ module.exports = function(io) {
         socket.emit('send twitch data', twitchData);
         connectedSockets++;
 
+        // if we go from 0 to 1 socket, start polling again
+        pollTwitch();
+
         socket.on('disconnect', function () {
             console.log('Twitch disconnected');
             connectedSockets--;
+            if (connectedSockets === 0) {
+                clearTimeout(timeout);
+            }
         });
 
         socket.on('update twitch user', function (data) {

--- a/sockets/twitch.js
+++ b/sockets/twitch.js
@@ -1,5 +1,6 @@
 var config = require('../config');
 var request = require('request');
+
 module.exports = function(io) {
     var twitchData = {};
     //In millis

--- a/sockets/twitch.js
+++ b/sockets/twitch.js
@@ -21,7 +21,8 @@ module.exports = function(io) {
         socket.on('disconnect', function () {
             console.log('Twitch disconnected');
             connectedSockets--;
-            if (connectedSockets === 0) {
+            if (connectedSockets <= 0) {
+                connectedSockets = 0;
                 clearTimeout(timeout);
             }
         });

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -246,15 +246,19 @@
 
 	var challongeSocket = io('/challonge');
 	var challongeMatches = [];
+	var challongeUrl;
 
 	challongeSocket.on('update challonge', function(data){
-		document.getElementById('challongeUrl').value = data.challongeUrl || '';
+		if (data.challongeUrl && (data.challongeUrl !== challongeUrl || document.getElementById('challongeBracket') === null)) {
+			document.getElementById('challongeUrl').value = data.challongeUrl || '';
+			challongeUrl = data.challongeUrl;
+			embedChallongeBracket(challongeUrl);
+		}
 
 		if (data.upcomingMatches) {
 			challongeMatches = data.upcomingMatches;
 			createMatchList(data);
 		}
-		embedChallongeBracket(data);
 	});
 
 	function plusOneLeft() {
@@ -313,6 +317,7 @@
 	}
 
 	function sendChallongeUpdate() {
+		var url = document.getElementById('challongeUrl').value;
 		var data = {
 			'challongeUrl': document.getElementById('challongeUrl').value
 		};
@@ -376,18 +381,16 @@
 		info.fadeOut(1200);
 	}
 
-	function embedChallongeBracket(data) {
-		var bracket = document.getElementById('challongeBracket');
-		if (data.challongeUrl && bracket == null) {
-			var embedded = document.createElement('iframe');
-			embedded.id = 'challongeBracket';
-			embedded.src = data.challongeUrl + '/module';
-			embedded.width = '100%';
-			embedded.height = '500';
-			embedded.frameboarder = '0';
-			embedded.scrolling = 'auto';
-			document.getElementById('challongeEmbedPlaceholder').appendChild(embedded);
-		}
+	function embedChallongeBracket(url) {
+		$('#challongeEmbedPlaceholder').empty();
+		var embedded = document.createElement('iframe');
+		embedded.id = 'challongeBracket';
+		embedded.src = url + '/module';
+		embedded.width = '100%';
+		embedded.height = '500';
+		embedded.frameboarder = '0';
+		embedded.scrolling = 'auto';
+		document.getElementById('challongeEmbedPlaceholder').appendChild(embedded);
 	}
 
 	function toggleNightMode() {

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -71,29 +71,29 @@
 			<input id="twitchUsername"></input>
 		</label>
 	</p>
-	<p class="requires-twitch">
+	<p class="requires-twitch hide-by-default">
 		<label for="twitchStatus">
 			Status:
 			<input id="twitchStatus" style="width: 90%"></input>
 		</label>
 	</p>
-	<p class="requires-twitch">
+	<p class="requires-twitch hide-by-default">
 		<label for="twitchGame">
 			Playing:
 			<input id="twitchGame"></input>
 		</label>
 	</p>
-	<p class="requires-twitch">
+	<p class="requires-twitch hide-by-default">
 	<label for="twitchViewers">
 		Current Viewers:
 		<input id="twitchViewers" class="twitch-pollable"></input>
 	</label>
-	<label for="twitchPeakViewers">
+	<label for="twitchPeakViewers hide-by-default">
 		Peak Viewers:
 		<input id="twitchPeakViewers" class="twitch-pollable"></input>
 	</label>
 	</p>
-	<p class="requires-twitch">
+	<p class="requires-twitch hide-by-default">
 	<label for="twitchFollowers">
 		Followers:
 		<input id="twitchFollowers" class="twitch-pollable"></input>
@@ -169,9 +169,6 @@
 			sendUpdate();
 		});
 	}
-
-	// hide twitch data inputs on load
-	animateTwitchData(false);
 
 	createCharacterList('Left');
 	createCharacterList('Right');

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -174,10 +174,6 @@
 	createCharacterList('Right');
 
 	var socket = io('/overlay');
-	socket.on('connect', function() {
-		socket.emit('request overlay');
-		//socket.emit('join', { room: 'overlay' });
-	});
 
 	socket.on('update overlay', function(data) {
 		document.getElementById('lplayer').value = data.lplayer || '';

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -159,7 +159,7 @@
 
 		$('#charList'+direction).change(function(){
 			var selectedOption = $('#charList'+direction+' option:selected');
-			
+
 			if(direction == 'Left') {
 				characterLeft = selectedOption.val();
 			}
@@ -169,6 +169,9 @@
 			sendUpdate();
 		});
 	}
+
+	// hide twitch data inputs on load
+	animateTwitchData(false);
 
 	createCharacterList('Left');
 	createCharacterList('Right');
@@ -192,29 +195,44 @@
 
 	var twitchSocket = io('/twitch');
 
-	twitchSocket.on('update twitch', function(data){
+	twitchSocket.on('send twitch data', function(data) {
 		document.getElementById('twitchUsername').value = data.twitchUsername || '';
 		document.getElementById('twitchStatus').value = data.twitchStatus || '';
 		document.getElementById('twitchGame').value = data.twitchGame || '';
-
-		animateTwitchData(data);
-	});
-
-	twitchSocket.on('update twitch readonly data', function(data) {
 		document.getElementById('twitchFollowers').value = data.twitchFollowers || 0;
 		document.getElementById('twitchLastFollower').value = data.twitchLastFollower || '';
 		document.getElementById('twitchViewers').value = data.twitchViewers || 'offline';
 		document.getElementById('twitchPeakViewers').value = data.twitchPeakViewers || 'offline';
-
-		animateTwitchData(data);
+		if (data.twitchUsername) {
+			animateTwitchData(true);
+		}
 	});
 
-	function animateTwitchData(data) {
-		if(data.twitchUsername) {
+	twitchSocket.on('update twitch followers', function(data) {
+		document.getElementById('twitchFollowers').value = data.followers || 0;
+		document.getElementById('twitchLastFollower').value = data.lastFollower || '';
+
+		animateTwitchData(true);
+	});
+
+	twitchSocket.on('update twitch viewers', function(data) {
+		document.getElementById('twitchViewers').value = data.twitchViewers || 'offline';
+		document.getElementById('twitchPeakViewers').value = data.twitchPeakViewers || 'offline';
+
+		animateTwitchData(true);
+	});
+
+	twitchSocket.on('update twitch channel info', function(data) {
+		document.getElementById('twitchStatus').value = data.status || '';
+		document.getElementById('twitchGame').value = data.game || '';
+
+		animateTwitchData(true);
+	});
+
+	function animateTwitchData(shouldShow) {
+		if (shouldShow) {
 			$('.requires-twitch').show(200);
-		}
-		else
-		{
+		} else {
 			$('.requires-twitch').hide(200);
 		}
 	}

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -191,10 +191,16 @@
 	});
 
 	var twitchSocket = io('/twitch');
+	var twitchGame = null;
+	var twitchStatus = null;
+	var twitchUsername = null;
 
 	twitchSocket.on('send twitch data', function(data) {
+		twitchUsername = data.twitchUsername;
 		document.getElementById('twitchUsername').value = data.twitchUsername || '';
+		twitchStatus = data.twitchStatus;
 		document.getElementById('twitchStatus').value = data.twitchStatus || '';
+		twitchGame = data.twitchGame;
 		document.getElementById('twitchGame').value = data.twitchGame || '';
 		document.getElementById('twitchFollowers').value = data.twitchFollowers || 0;
 		document.getElementById('twitchLastFollower').value = data.twitchLastFollower || '';
@@ -220,8 +226,12 @@
 	});
 
 	twitchSocket.on('update twitch channel info', function(data) {
+		twitchStatus = data.status;
 		document.getElementById('twitchStatus').value = data.status || '';
+		twitchGame = data.twitchGame;
 		document.getElementById('twitchGame').value = data.game || '';
+		twitchUsername = data.twitchUsername;
+		document.getElementById('twitchUsername').value = data.username || '';
 
 		animateTwitchData(true);
 	});
@@ -288,12 +298,17 @@
 	}
 
 	function sendTwitchUpdate() {
-		var data = {
-			'twitchUsername': document.getElementById('twitchUsername').value,
-			'twitchStatus': document.getElementById('twitchStatus').value,
-			'twitchGame': document.getElementById('twitchGame').value
-		};
-		twitchSocket.emit('update twitch', data);
+		var user = document.getElementById('twitchUsername').value;
+		if (twitchUsername !== user) {
+			twitchSocket.emit('update twitch user', user);
+		} else {
+			var data = {
+				'status': document.getElementById('twitchStatus').value,
+				'game': document.getElementById('twitchGame').value
+			};
+			twitchSocket.emit('update twitch channel info', data);
+		}
+
 		toastNotify();
 	}
 

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -250,7 +250,7 @@
 	challongeSocket.on('update challonge', function(data){
 		document.getElementById('challongeUrl').value = data.challongeUrl || '';
 
-		if(data.upcomingMatches && data.matchesChanged) {
+		if (data.upcomingMatches) {
 			challongeMatches = data.upcomingMatches;
 			createMatchList(data);
 		}


### PR DESCRIPTION
Twitch functionality was crashing the server because sometimes we would call the Twitch API and attempt to read the response before it was returned. This branch refactors the Twitch and Challonge sockets to send data in async callbacks. In the process I swapped out xmlhttprequest for the request library, which seems to be more commonly used in node world.

@Camtendo want to take a look?

Fixes #37