### PR TITLE
ReadyScreen

### DIFF
--- a/public/javascripts/overlays/admin.js
+++ b/public/javascripts/overlays/admin.js
@@ -56,6 +56,15 @@ socket.on('update overlay', function(data) {
 	document.getElementById('rscore').value = data.rscore || 0;
 	characterLeft = data.lCharacter || null;
 	characterRight = data.rCharacter || null;
+
+	if(data.readyStatus) {
+		document.getElementById('ready-radio-false').checked = false;
+		document.getElementById('ready-radio-true').checked = true;
+	}
+	else {
+		document.getElementById('ready-radio-false').checked = true;
+		document.getElementById('ready-radio-true').checked = false;
+	}
 });
 
 var twitchSocket = io('/twitch');
@@ -152,6 +161,11 @@ function swapNames() {
 function zeroScores() {
 	document.getElementById('lscore').value = 0;
 	document.getElementById('rscore').value = 0;
+
+	//There's high probability that we are still typing information
+	//when scores are zeroed
+	document.getElementById('ready-radio-false').checked = true;
+	document.getElementById('ready-radio-true').checked = false;
 	sendUpdate();
 }
 
@@ -165,7 +179,8 @@ function sendUpdate() {
 		'commentators': document.getElementById('commentators').value,
 		'twitter': document.getElementById('twitter').value,
 		'lCharacter': window.characterLeft || null,
-		'rCharacter': window.characterRight || null
+		'rCharacter': window.characterRight || null,
+		'readyStatus': document.getElementById('ready-radio-true').checked
 	};
 	socket.emit('update overlay', data);
 	toastNotify();

--- a/routes/index.js
+++ b/routes/index.js
@@ -57,6 +57,11 @@ router.get('/overlays/commentators', function(req, res) {
   res.render('overlays/commentators', { title: 'Overlay', layout: false });
 });
 
+/* GET readyStatus page. */
+router.get('/overlays/readyStatus', function(req, res) {
+  res.render('overlays/readyStatus', { title: 'Ready Status', layout: false });
+});
+
 /* GET idle page. */
 router.get('/overlays/idle', function(req, res) {
   res.render('overlays/idle', { title: 'We will be right back!', layout: false });

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -6,6 +6,11 @@
 			Title
 			<input id="title"></input>
 		</label>
+
+		<input id="ready-radio-false" type="radio" name="readyStatus" value="false" onchange="sendUpdate()" checked>
+      Not Ready
+      <input id="ready-radio-true" type="radio" name="readyStatus" value="true" onchange="sendUpdate()">
+      Ready
 	</p>
 
 	<p>

--- a/views/overlays/readyStatus.hbs
+++ b/views/overlays/readyStatus.hbs
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{title}}</title>
+  </head>
+  <body style="text-align: center; width: 100%; height: 100%;">
+  	<h1 id="readyStatus"></h1>
+    <script src="/socket.io/socket.io.js"></script>
+    <script>
+      var readyString = 'The stream is ready! You may play your set.';
+      var notReadyString = 'Please wait. The stream team is updating information.';
+      var socket = io('/overlay');
+
+      socket.on('update overlay', function(data) {
+        document.getElementById('readyStatus').innerText = data.readyStatus ? readyString : notReadyString;
+        document.body.style.background = data.readyStatus ? 'green' : 'red';
+        document.body.style.color = data.readyStatus ? 'white' : 'black';
+      });
+    </script>
+  </body>
+</html>

--- a/views/overlays/readyStatus.hbs
+++ b/views/overlays/readyStatus.hbs
@@ -3,7 +3,7 @@
   <head>
     <title>{{title}}</title>
   </head>
-  <body style="text-align: center; width: 100%; height: 100%;">
+  <body style="text-align: center;">
   	<h1 id="readyStatus"></h1>
     <script src="/socket.io/socket.io.js"></script>
     <script>


### PR DESCRIPTION
Creates a "Ready Status" view for players. Requires a tablet/computer.

Upon clicking "ready", players will be shown a green screen (and white text). At start and when zeroing scores after a match, the players will be shown a red screen (with black text) suggesting they hold their horses. Updates extremely quickly due to lightweight JS.

Closes https://github.com/dguenther/web-overlay/issues/72