### PR TITLE
Display new follows from queue on button click

### DIFF
--- a/public/javascripts/overlays/admin.js
+++ b/public/javascripts/overlays/admin.js
@@ -455,6 +455,12 @@ $(function() {
     $('#twitch-log-out').click(function() {
         twitchSocket.emit('log out');
     });
+
+    $('#twitch-process-followers').click(function() {
+        console.log('Follower processing requested...');
+        twitchSocket.emit('process followers');
+    });
+
     $('#challonge-clear-bracket').click(function() {
         challongeSocket.emit('clear bracket');
     });

--- a/sockets/twitch.js
+++ b/sockets/twitch.js
@@ -290,6 +290,10 @@ module.exports = function(io) {
             }
 
             twitchData.newFollowers = newFollowers;
+            if(numNewFollowers != twitchData.twitchFollowers) {
+                numFollowersAtLaunch = twitchData.twitchFollowers;
+            }
+            
             twitchIO.emit('send twitch data', twitchData);
         }
 

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -159,6 +159,7 @@
             </form>
             <button id="twitch-log-out">Log Out</button>
             <button id="twitch-reset">Reset Peak Viewers</button>
+            <button id="twitch-process-followers">Process Follower Queue</button>
         </div>
 
         <div id="tab3" class="tab">

--- a/views/overlays/commentators.hbs
+++ b/views/overlays/commentators.hbs
@@ -2,6 +2,9 @@
 <html>
   <head>
     <title>{{title}}</title>
+    <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+    <link rel='stylesheet' href='http://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css' />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/js/toastr.js"></script>
     <link rel='stylesheet' href='/stylesheets/overlays/commentators.css' />
     <script src="/socket.io/socket.io.js"></script>
   </head>
@@ -10,11 +13,54 @@
   		<div id="commentators" class="playertext"></div>
   	</div>
     <script>
+    var processedFollowers = [];
 		var socket = io('/overlay');
 
 		socket.on('update overlay', function(data) {
 			document.getElementById('commentators').innerText = data.commentators || '';
 		});
+
+    var twitchSocket = io('/twitch');
+
+    twitchSocket.on('send twitch data', function(data){
+      console.log(data);
+        if(!data.newFollowers) {
+          console.log('No new followers found.');
+          return;
+        }
+
+        if(!toastr) {
+          console.log('Toastr not loaded');
+          return;
+        }
+
+        toastr.options = {
+              "closeButton": false,
+              "debug": true,
+              "newestOnTop": true,
+              "progressBar": true,
+              "positionClass": "toast-top-right",
+              "preventDuplicates": false,
+              "showDuration": "300",
+              "hideDuration": "1000",
+              "timeOut": "60000",
+              "extendedTimeOut": "60000",
+              "showEasing": "swing",
+              "hideEasing": "swing",
+              "showMethod": "slideDown",
+              "hideMethod": "fadeOut"
+            }
+
+        for(var i=0; i<data.newFollowers.length; i++) {
+          if(processedFollowers.indexOf(data.newFollowers[i]) == -1) {
+
+            console.log('Beginning to process followers:');
+            toastr['info'](data.newFollowers[i], "New follower!");
+            processedFollowers.push(data.newFollowers[i]);
+            console.log('Processed '+data.newFollowers[i]);
+          }
+        }
+    });
     </script>
   </body>
 </html>


### PR DESCRIPTION
This branch allows us to collect new followers continuously in a queue, then pop them all at a convenient time. We display new follows using toastr.js. This works and is pretty annoying to test as you need fake accounts and Twitch does not process new follows immediately.

Closes https://github.com/dguenther/web-overlay/issues/33